### PR TITLE
Include relevant header for case insensitive string functions

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -16,6 +16,8 @@ Http server - core routines
 #include <libesphttpd/esp.h>
 #endif
 
+#include <strings.h>
+
 #include "libesphttpd/httpd.h"
 #include "httpd-platform.h"
 


### PR DESCRIPTION
Without including this header, the compilation fails due to an implicit function declaration error.