### PR TITLE
Sanitize Client's URL Requests

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -90,3 +90,11 @@ config ESPHTTPD_BACKLOG_SUPPORT
 		no need for the backlog.
 
 		If you are using FreeRTOS you'll save codespace by leaving this option disabled.
+
+config ESPHTTPD_SANITIZE_URLS
+	bool "Sanitize client requests"
+	depends on ESPHTTPD_ENABLED
+	default y
+	help
+		Sanitize client's URL requests by treating multiple repeated slashes in the
+		URL's path as a single slash.

--- a/core/httpd.c
+++ b/core/httpd.c
@@ -684,6 +684,17 @@ static CallbackStatus ICACHE_FLASH_ATTR httpdParseHeader(char *h, HttpdConnData 
         } else {
             conn->getArgs=NULL;
         }
+
+#ifdef CONFIG_ESPHTTPD_SANITIZE_URLS
+        // Remove multiple repeated slashes in URL path.
+        while((e = strstr(conn->url, "//")) != NULL){
+            // Move string starting at second slash one place to the left.
+            // Use strlen() on the first slash so the '\0' will be copied too.
+            ESP_LOGD(TAG, "Cleaning up URL path: %s", conn->url);
+            memmove(e, e + 1, strlen(e));
+            ESP_LOGD(TAG, "Cleaned URL path: %s", conn->url);
+        }
+#endif // CONFIG_ESPHTTPD_SANITIZE_URLS
     } else if (strncasecmp(h, "Connection:", 11)==0) {
         i=11;
         //Skip trailing spaces


### PR DESCRIPTION
- add KConfig option ESPHTTPD_SANITIZE_URLS. If enabled, server will ignore
  repeated slashes in requested paths and treat them as a single slash.