### PR TITLE
Allow custom control flow with platHttpServerTask

### DIFF
--- a/core/httpd-freertos.c
+++ b/core/httpd-freertos.c
@@ -190,18 +190,16 @@ static bool sslSetDerCertificateAndKey(HttpdFreertosInstance *pInstance,
 
 #ifdef linux
 
-#define PLAT_RETURN void*
 #define PLAT_TASK_EXIT return NULL
 
 #else
 
-#define PLAT_RETURN void
 #define PLAT_TASK_EXIT vTaskDelete(NULL)
 
 #endif
 
 
-static PLAT_RETURN platHttpServerTask(void *pvParameters)
+PLAT_RETURN platHttpServerTask(void *pvParameters)
 {
     int32 listenfd;
     int32 remotefd;

--- a/include/libesphttpd/httpd-freertos.h
+++ b/include/libesphttpd/httpd-freertos.h
@@ -21,6 +21,13 @@
 #include <netinet/in.h>
 #endif
 
+
+#ifdef linux
+    #define PLAT_RETURN void*
+#else
+    #define PLAT_RETURN void
+#endif
+
 struct RtosConnType{
 	int fd;
 	int needWriteDoneNotif;
@@ -66,6 +73,11 @@ typedef struct
 
     HttpdInstance httpdInstance;
 } HttpdFreertosInstance;
+
+/**
+ * Manually execute webserver task - do not use with httpdFreertosStart
+ */
+PLAT_RETURN platHttpServerTask(void *pvParameters);
 
 /*
  * connectionBuffer should be sized 'sizeof(RtosConnType) * maxConnections'


### PR DESCRIPTION
Hello chmorgan,

As you already moved the task/thread start code to httpdFreertosStart it is now easy to call platHttpServerTask manually in sequence with other stuff I have to do. This pull request only makes platHttpServerTask public so it can be called manually. 

Best regards,

Paul