### PR TITLE
Renamed base64_decode and base64_encode because they can collide with…

### DIFF
--- a/core/auth.c
+++ b/core/auth.c
@@ -13,7 +13,7 @@ HTTP auth implementation. Only does basic authentication for now.
 #endif
 
 #include "libesphttpd/auth.h"
-#include "base64.h"
+#include "libesphttpd_base64.h"
 
 CgiStatus ICACHE_FLASH_ATTR authBasic(HttpdConnData *connData) {
 	const char *unauthorized = "401 Unauthorized.";
@@ -32,7 +32,7 @@ CgiStatus ICACHE_FLASH_ATTR authBasic(HttpdConnData *connData) {
 
 	r=httpdGetHeader(connData, "Authorization", hdr, sizeof(hdr));
 	if (r && strncmp(hdr, "Basic", 5)==0) {
-		r=base64_decode(strlen(hdr)-6, hdr+6, sizeof(userpass), (unsigned char *)userpass);
+		r=libesphttpd_base64_decode(strlen(hdr)-6, hdr+6, sizeof(userpass), (unsigned char *)userpass);
 		if (r<0) r=0; //just clean out string on decode error
 		userpass[r]=0; //zero-terminate user:pass string
 //		printf("Auth: %s\n", userpass);

--- a/core/base64.h
+++ b/core/base64.h
@@ -1,6 +1,0 @@
-#ifndef BASE64_H
-#define BASE64_H
-
-int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
-int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
-#endif

--- a/core/libesphttpd_base64.c
+++ b/core/libesphttpd_base64.c
@@ -10,7 +10,7 @@
 #include <libesphttpd/esp.h>
 #endif
 
-#include "base64.h"
+#include "libesphttpd_base64.h"
 
 static const int base64dec_tab[256] ICACHE_RODATA_ATTR={
 	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
@@ -48,7 +48,7 @@ static int ICACHE_FLASH_ATTR base64decode(const char in[4], char out[3]) {
 #endif
 
 /* decode a base64 string in one shot */
-int ICACHE_FLASH_ATTR  __attribute__((weak)) base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
+int ICACHE_FLASH_ATTR  __attribute__((weak)) libesphttpd_base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
 	unsigned int ii, io;
 	uint32_t v;
 	unsigned int rem;
@@ -86,7 +86,7 @@ void base64encode(const unsigned char in[3], unsigned char out[4], int count) {
 }
 #endif
 
-int ICACHE_FLASH_ATTR __attribute__((weak)) base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
+int ICACHE_FLASH_ATTR __attribute__((weak)) libesphttpd_base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
 	unsigned ii, io;
 	uint32_t v;
 	unsigned rem;

--- a/core/libesphttpd_base64.h
+++ b/core/libesphttpd_base64.h
@@ -1,6 +1,4 @@
-#ifndef LIBESPHTTPD_BASE64_H
-#define LIBESPHTTPD_BASE64_H
+#pragma once
 
 int libesphttpd_base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
 int libesphttpd_base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
-#endif

--- a/core/libesphttpd_base64.h
+++ b/core/libesphttpd_base64.h
@@ -1,0 +1,6 @@
+#ifndef LIBESPHTTPD_BASE64_H
+#define LIBESPHTTPD_BASE64_H
+
+int libesphttpd_base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
+int libesphttpd_base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
+#endif

--- a/util/cgiwebsocket.c
+++ b/util/cgiwebsocket.c
@@ -14,7 +14,7 @@ Websocket support for esphttpd. Inspired by https://github.com/dangrie158/ESP-82
 
 #include "libesphttpd/httpd.h"
 #include "libesphttpd/sha1.h"
-#include "base64.h"
+#include "libesphttpd_base64.h"
 #include "libesphttpd/cgiwebsocket.h"
 
 #include "esp_log.h"
@@ -335,7 +335,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiWebsocket(HttpdConnData *connData) {
 				httpdStartResponse(connData, 101);
 				httpdHeader(connData, "Upgrade", "websocket");
 				httpdHeader(connData, "Connection", "upgrade");
-				base64_encode(20, sha1_result(&s), sizeof(buff), buff);
+				libesphttpd_base64_encode(20, sha1_result(&s), sizeof(buff), buff);
 				httpdHeader(connData, "Sec-WebSocket-Accept", buff);
 				httpdEndHeaders(connData);
 				//Set data receive handler


### PR DESCRIPTION
… symbols in ESP-IDF if WPA functions like esp_wifi_sta_wpa2_ent_set_identity are used (see esp32.rom.ld). This can lead to the wrong address being called and a wrong result.