### PR TITLE
Improve flash-api

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -61,6 +61,13 @@ config ESPHTTPD_USEUGLIFYJS
 	default n
 	help
 		Compress JS files with the uglifyjs compressor. Needs uglifyjs installed.
+        
+config ESPHTTPD_USEYUICOMPRESSOR
+	bool "Compress JS and css with yui-compressor"
+        depends on ESPHTTPD_ENABLED
+	default n
+	help
+		Compress JS and css files with the yui-compressor. Needs yui-compressor installed.
 
 config ESPHTTPD_SO_REUSEADDR
 	bool "Set SO_REUSEADDR to avoid waiting for a port in TIME_WAIT."

--- a/README-flash_api.md
+++ b/README-flash_api.md
@@ -1,0 +1,144 @@
+# Libesphttpd Flash-API
+
+The flash API is specified in RAML.  (see https://raml.org)
+```yaml
+#%RAML 1.0
+title: flash
+version: v1
+baseUri: http://me.local/flash
+
+
+/flashinfo.json:
+    description: info about the partition table
+    get:
+        description: Returns a JSON of info about the partition table
+        queryParameters:
+            type:
+                displayName: Partition Type
+                type: string
+                description: String name of partition type (app, data).  If not specified, return both app and data partitions.
+                example: app
+                required: false
+        responses:
+            200:
+                body:
+                    application/json:
+                      type: object
+                      properties:
+                        app: array
+                        data: array
+                      example: |
+                        {
+                            "app":	[{
+                                    "name":	"factory",
+                                    "size":	4259840,
+                                    "version":	"",
+                                    "ota":	false,
+                                    "valid":	true,
+                                    "running":	false,
+                                    "bootset":	false
+                                }, {
+                                    "name":	"ota_0",
+                                    "size":	4259840,
+                                    "version":	"",
+                                    "ota":	true,
+                                    "valid":	true,
+                                    "running":	true,
+                                    "bootset":	true
+                                }, {
+                                    "name":	"ota_1",
+                                    "size":	4259840,
+                                    "version":	"",
+                                    "ota":	true,
+                                    "valid":	true,
+                                    "running":	false,
+                                    "bootset":	false
+                                }],
+                            "data":	[{
+                                    "name":	"nvs",
+                                    "size":	16384,
+                                    "format":	2
+                                }, {
+                                    "name":	"otadata",
+                                    "size":	8192,
+                                    "format":	0
+                                }, {
+                                    "name":	"phy_init",
+                                    "size":	4096,
+                                    "format":	1
+                                }, {
+                                    "name":	"internalfs",
+                                    "size":	3932160,
+                                    "format":	129
+                                }]
+                        }
+
+/setboot:
+    description: boot flag
+    get:
+        description: Set the boot flag.  example GET /flash/setboot?partition=ota_1
+        queryParameters:
+            partition:
+                displayName: Partition
+                type: string
+                description: String name of partition (i.e. factory, ota_0, ota_1).  If not specified, just return the current setting.
+                example: ota_0
+                required: false
+        responses:
+            200:
+                body:
+                    application/json:
+                      type: object
+                      properties:
+                        success: boolean
+                        boot: string
+                      example: |
+                        {
+                          "success": true
+                          "boot": "ota_0"
+                        }
+                        
+/reboot:
+    description: Reboot the processor
+    get:
+        description: Reboot the processor.  example GET /flash/reboot
+        responses:
+            200:
+                body:
+                    application/json:
+                      type: object
+                      properties:
+                        success: boolean
+                        message: string
+                      example: |
+                        {
+                          "success": true
+                          "message": "Rebooting..."
+                        }
+                        
+
+/upload:
+    description: Upload APP firmware to flash memory
+    post:
+        description: Upload APP firmware to flash memory.
+        queryParameters:
+            partition:
+                displayName: Partition
+                type: string
+                description: String name of partition (i.e. factory, ota_0, ota_1).  If not specified, automatically choose the next available OTA slot.
+                example: ota_0
+                required: false
+        responses:
+            200:
+                body:
+                    application/json:
+                      type: object
+                      properties:
+                        success: boolean
+                        message: string
+                      example: |
+                          {
+                              "success": true
+                              "message": "Flash Success."
+                          }
+```

--- a/README-flash_api.md
+++ b/README-flash_api.md
@@ -1,5 +1,14 @@
 # Libesphttpd Flash-API
 
+Functions to flash firmware Over-The-Air.  These are only useful if you have enabled OTA support.
+
+The simplest way to use the partition table is to make menuconfig and choose the simple predefined partition table:
+
+    “Factory app, two OTA definitions”
+
+## GUI
+See the example js/html code for the GUI here: https://github.com/phatpaul/esphttpd-freertos/blob/master/html/flash/index.html
+
 ## Functions defined in cgiflash.h
 
 * __cgiGetFirmwareNext()__
@@ -21,8 +30,6 @@ CGI function to erase flash memory.  (only supports erasing data partitions)
 CGI function returns a JSON object describing the partition table.  It can also verify the firmware images, but not by default because that process takes several seconds.
 
 ## HTTP REST API
-
-See the example js/html code for the GUI here: https://github.com/phatpaul/esphttpd-freertos/blob/master/html/flash/index.html
 
 The flash API is specified in RAML.  (see https://raml.org)
 

--- a/README.md
+++ b/README.md
@@ -101,18 +101,7 @@ of a DNS-server (started by calling `captdnsInit()`) resolving all hostnames int
 ESP8266/ESP32. These redirect functions can then be used to further redirect the client to the hostname of 
 the ESP8266/ESP32.
 
-* __cgiReadFlash__ (arg: none)
-Will serve up the SPI flash of the ESP8266/ESP32 as a binary file.
-
-* __cgiGetFirmwareNext__ (arg: CgiUploadFlashDef flash description data)
-For OTA firmware upgrade: indicates if the user1 or user2 firmware needs to be sent to the ESP to do
-an OTA upgrade
-
-* __cgiUploadFirmware__ (arg: CgiUploadFlashDef flash description data)
-Accepts a POST request containing the user1 or user2 firmware binary and flashes it to the SPI flash
-
-* __cgiRebootFirmware__ (arg: none)
-Reboots the ESP8266/ESP32 to the newly uploaded code after a firmware upload.
+* Flash updating functions (OTA) - see [README-flash_api](./README-flash_api.md)
 
 * __cgiWiFi* functions__ (arg: various)
 These are used to change WiFi mode, scan for access points, associate to an access point etcetera. See

--- a/include/libesphttpd/cgiflash.h
+++ b/include/libesphttpd/cgiflash.h
@@ -18,6 +18,7 @@ CgiStatus cgiGetFirmwareNext(HttpdConnData *connData);
 CgiStatus cgiUploadFirmware(HttpdConnData *connData);
 CgiStatus cgiRebootFirmware(HttpdConnData *connData);
 CgiStatus cgiSetBoot(HttpdConnData *connData);
+CgiStatus cgiEraseFlash(HttpdConnData *connData);
 CgiStatus cgiGetFlashInfo(HttpdConnData *connData);
 
 #endif

--- a/include/libesphttpd/cgiflash.h
+++ b/include/libesphttpd/cgiflash.h
@@ -17,5 +17,7 @@ typedef struct {
 CgiStatus cgiGetFirmwareNext(HttpdConnData *connData);
 CgiStatus cgiUploadFirmware(HttpdConnData *connData);
 CgiStatus cgiRebootFirmware(HttpdConnData *connData);
+CgiStatus cgiSetBoot(HttpdConnData *connData);
+CgiStatus cgiGetFlashInfo(HttpdConnData *connData);
 
 #endif

--- a/util/cgiflash.c
+++ b/util/cgiflash.c
@@ -9,12 +9,8 @@ Some flash handling cgi routines. Used for updating the ESPFS/OTA image.
 #include <libesphttpd/esp.h>
 #include "libesphttpd/cgiflash.h"
 #include "libesphttpd/espfs.h"
-#include "libesphttpd/cgiflash.h"
-#include "libesphttpd/espfs.h"
 #include "cJSON.h"
-//#include <osapi.h>
-#include "libesphttpd/cgiflash.h"
-#include "libesphttpd/espfs.h"
+
 #include "httpd-platform.h"
 #ifdef ESP32
 #include "esp32_flash.h"

--- a/util/cgiflash.c
+++ b/util/cgiflash.c
@@ -20,6 +20,8 @@ Some flash handling cgi routines. Used for updating the ESPFS/OTA image.
 #include "esp32_flash.h"
 #include "esp_ota_ops.h"
 #include "esp_log.h"
+#include "esp_flash_data_types.h"
+#include "esp_image_format.h"
 
 static const char *TAG = "ota";
 #endif
@@ -129,6 +131,25 @@ typedef struct __attribute__((packed)) {
 } OtaHeader;
 #endif
 
+static void cgiJsonResponseCommon(HttpdConnData *connData, cJSON *jsroot){
+	char *json_string = NULL;
+
+	//// Generate the header
+	//We want the header to start with HTTP code 200, which means the document is found.
+	httpdStartResponse(connData, 200);
+	httpdHeader(connData, "Cache-Control", "no-store, must-revalidate, no-cache, max-age=0");
+	httpdHeader(connData, "Expires", "Mon, 01 Jan 1990 00:00:00 GMT");  //  This one might be redundant, since modern browsers look for "Cache-Control".
+	httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
+	httpdEndHeaders(connData);
+	json_string = cJSON_Print(jsroot);
+    if (json_string)
+    {
+    	httpdSend(connData, json_string, -1);
+        cJSON_free(json_string);
+    }
+    cJSON_Delete(jsroot);
+}
+
 #ifdef ESP32
 CgiStatus ICACHE_FLASH_ATTR cgiUploadFirmware(HttpdConnData *connData) {
 	CgiUploadFlashDef *def=(CgiUploadFlashDef*)connData->cgiArg;
@@ -174,7 +195,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiUploadFirmware(HttpdConnData *connData) {
 		}
 		state->update_partition = NULL;
 		// check arg partition name
-		char arg_partition_buf[10] = "";
+		char arg_partition_buf[16] = "";
 		int len;
 	    len=httpdFindArg(connData->getArgs, "partition", arg_partition_buf, sizeof(arg_partition_buf));
 	    if (len > 0)
@@ -277,14 +298,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiUploadFirmware(HttpdConnData *connData) {
 #endif
 
 	if  (connData->post.len == connData->post.received) {
-		cJSON *root = NULL;
-		char *json_string = NULL;
-		root = cJSON_CreateObject();
-		//We're done! Format a response.
-		ESP_LOGI(TAG, "Upload done. Sending response");
-		httpdStartResponse(connData, state->state==FLST_ERROR?400:200);
-		httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
-		httpdEndHeaders(connData);
+		cJSON *jsroot = cJSON_CreateObject();
 		if (state->state==FLST_DONE) {
 			if (esp_ota_end(state->update_handle) != ESP_OK) {
 				state->err="esp_ota_end failed!";
@@ -294,23 +308,19 @@ CgiStatus ICACHE_FLASH_ATTR cgiUploadFirmware(HttpdConnData *connData) {
 			else
 			{
 				state->err="Flash Success.";
+				ESP_LOGI(TAG, "Upload done. Sending response");
 			}
-//		    err = esp_ota_set_boot_partition(state->update_partition);
-//		    if (err != ESP_OK) {
-//		        ESP_LOGE(TAG, "esp_ota_set_boot_partition failed! err=0x%x", err);
-//		    }
+			// todo: automatically set boot flag?
+			err = esp_ota_set_boot_partition(state->update_partition);
+			if (err != ESP_OK) {
+				ESP_LOGE(TAG, "esp_ota_set_boot_partition failed! err=0x%x", err);
+			}
 		}
-		cJSON_AddStringToObject(root, "message", state->err);
-		cJSON_AddBoolToObject(root, "success", (state->state==FLST_DONE)?true:false);
-		json_string = cJSON_Print(root);
-	    if (json_string)
-	    {
-	    	httpdSend(connData, json_string, -1);
-	        cJSON_free(json_string);
-	    }
-	    cJSON_Delete(root);
+		cJSON_AddStringToObject(jsroot, "message", state->err);
+		cJSON_AddBoolToObject(jsroot, "success", (state->state==FLST_DONE)?true:false);
 		free(state);
 
+		cgiJsonResponseCommon(connData, jsroot); // Send the json response!
 		return HTTPD_CGI_DONE;
 	}
 
@@ -504,9 +514,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiRebootFirmware(HttpdConnData *connData) {
 		//Connection aborted. Clean up.
 		return HTTPD_CGI_DONE;
 	}
-	cJSON *root = NULL;
-	char *json_string = NULL;
-	root = cJSON_CreateObject();
+	cJSON *jsroot = cJSON_CreateObject();
 
 	ESP_LOGD(TAG, "Reboot Command recvd. Sending response");
 	// TODO: sanity-check that the 'next' partition actually contains something that looks like
@@ -516,24 +524,9 @@ CgiStatus ICACHE_FLASH_ATTR cgiRebootFirmware(HttpdConnData *connData) {
 	resetTimer=httpdPlatTimerCreate("flashreset", 500, 0, resetTimerCb, NULL);
 	httpdPlatTimerStart(resetTimer);
 
-	//// Generate the header
-	//We want the header to start with HTTP code 200, which means the document is found.
-	httpdStartResponse(connData, 200);
-	httpdHeader(connData, "Cache-Control", "no-store, must-revalidate, no-cache, max-age=0");
-	httpdHeader(connData, "Expires", "Mon, 01 Jan 1990 00:00:00 GMT");  //  This one might be redundant, since modern browsers look for "Cache-Control".
-	httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
-	httpdEndHeaders(connData);
-
-	cJSON_AddStringToObject(root, "message", "Rebooting...");
-	cJSON_AddBoolToObject(root, "success", true);
-	json_string = cJSON_Print(root);
-    if (json_string)
-    {
-    	httpdSend(connData, json_string, -1);
-        cJSON_free(json_string);
-    }
-    cJSON_Delete(root);
-
+	cJSON_AddStringToObject(jsroot, "message", "Rebooting...");
+	cJSON_AddBoolToObject(jsroot, "success", true);
+	cgiJsonResponseCommon(connData, jsroot); // Send the json response!
 	return HTTPD_CGI_DONE;
 }
 
@@ -545,11 +538,10 @@ CgiStatus ICACHE_FLASH_ATTR cgiSetBoot(HttpdConnData *connData) {
 	}
 	const esp_partition_t *wanted_bootpart = NULL;
 	const esp_partition_t *actual_bootpart = NULL;
-	cJSON *root = NULL;
-	char *json_string = NULL;
-	root = cJSON_CreateObject();
+	cJSON *jsroot = cJSON_CreateObject();
+
 	// check arg partition name
-	char arg_partition_buf[10] = "";
+	char arg_partition_buf[16] = "";
 	int len;
     len=httpdFindArg(connData->getArgs, "partition", arg_partition_buf, sizeof(arg_partition_buf));
     if (len > 0)
@@ -564,28 +556,69 @@ CgiStatus ICACHE_FLASH_ATTR cgiSetBoot(HttpdConnData *connData) {
     }
     actual_bootpart = esp_ota_get_boot_partition();
 
+	cJSON_AddStringToObject(jsroot, "boot", actual_bootpart->label);
+	cJSON_AddBoolToObject(jsroot, "success", (wanted_bootpart == NULL || wanted_bootpart == actual_bootpart));
 
-	//// Generate the header
-	//We want the header to start with HTTP code 200, which means the document is found.
-	httpdStartResponse(connData, 200);
-	httpdHeader(connData, "Cache-Control", "no-store, must-revalidate, no-cache, max-age=0");
-	httpdHeader(connData, "Expires", "Mon, 01 Jan 1990 00:00:00 GMT");  //  This one might be redundant, since modern browsers look for "Cache-Control".
-	httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
-	httpdEndHeaders(connData);
-
-	cJSON_AddStringToObject(root, "boot", actual_bootpart->label);
-	cJSON_AddBoolToObject(root, "success", (wanted_bootpart == NULL || wanted_bootpart == actual_bootpart));
-	json_string = cJSON_Print(root);
-    if (json_string)
-    {
-    	httpdSend(connData, json_string, -1);
-        cJSON_free(json_string);
-    }
-    cJSON_Delete(root);
-
+	cgiJsonResponseCommon(connData, jsroot); // Send the json response!
 	return HTTPD_CGI_DONE;
 }
 
+// Handle request to format a data partition
+CgiStatus ICACHE_FLASH_ATTR cgiEraseFlash(HttpdConnData *connData) {
+	if (connData->isConnectionClosed) {
+		//Connection aborted. Clean up.
+		return HTTPD_CGI_DONE;
+	}
+	const esp_partition_t *wanted_partition = NULL;
+	cJSON *jsroot = cJSON_CreateObject();
+	esp_err_t err = ESP_FAIL;
+
+	// check arg partition name
+	char arg_partition_buf[16] = "";
+	int len;
+    len=httpdFindArg(connData->getArgs, "partition", arg_partition_buf, sizeof(arg_partition_buf));
+    if (len > 0)
+    {
+    	ESP_LOGD(TAG, "Erase command recvd. for partition with name: %s", arg_partition_buf);
+    	wanted_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,ESP_PARTITION_SUBTYPE_ANY,arg_partition_buf);
+    	err = esp_partition_erase_range(wanted_partition, 0, wanted_partition->size);
+    	if (err != ESP_OK) {
+    		ESP_LOGE(TAG, "erase partition failed! err=0x%x", err);
+    	}
+    	else
+    	{
+    		ESP_LOGW(TAG, "Data partition: %s is erased now!  Must reboot to reformat it!", wanted_partition->label);
+    	}
+    }
+
+	cJSON_AddBoolToObject(jsroot, "success", (err == ESP_OK));
+
+	cgiJsonResponseCommon(connData, jsroot); // Send the json response!
+	return HTTPD_CGI_DONE;
+}
+
+/* @brief Check if selected partition has a valid APP
+ *  Warning- this takes a long time to execute and dumps a bunch of stuff to the console!
+ *  todo: find a faster method to veryify an APP
+ */
+static int check_partition_valid_app(const esp_partition_t *partition)
+{
+    if (partition == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_image_metadata_t data;
+    const esp_partition_pos_t part_pos = {
+        .offset = partition->address,
+        .size = partition->size,
+    };
+    if (esp_image_load(ESP_IMAGE_VERIFY_SILENT, &part_pos, &data) != ESP_OK) {
+        return 0;  // partition does not hold a valid app
+    }
+    return 1; // App in partition is valid
+}
+#define PARTITION_IS_FACTORY(partition)  ((partition->type == ESP_PARTITION_TYPE_APP) && (partition->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY))
+#define PARTITION_IS_OTA(partition)  ((partition->type == ESP_PARTITION_TYPE_APP) && (partition->subtype >= ESP_PARTITION_SUBTYPE_APP_OTA_MIN) && (partition->subtype <= ESP_PARTITION_SUBTYPE_APP_OTA_MAX))
 // Cgi to query info about partitions and firmware
 CgiStatus ICACHE_FLASH_ATTR cgiGetFlashInfo(HttpdConnData *connData) {
 	if (connData->isConnectionClosed) {
@@ -594,50 +627,73 @@ CgiStatus ICACHE_FLASH_ATTR cgiGetFlashInfo(HttpdConnData *connData) {
 	}
 	const esp_partition_t *running_partition = NULL;
 	const esp_partition_t *boot_partition = NULL;
-	const esp_partition_t *it_partition = NULL;
 	const esp_partition_subtype_t subtypes[] = {ESP_PARTITION_SUBTYPE_APP_FACTORY, ESP_PARTITION_SUBTYPE_APP_OTA_0, ESP_PARTITION_SUBTYPE_APP_OTA_1};
-	int it;
-	cJSON *root = NULL;
-	char *json_string = NULL;
-	root = cJSON_CreateArray();
-	// check arg partition name
 
-	boot_partition = esp_ota_get_boot_partition();
-	running_partition = esp_ota_get_running_partition();
+	cJSON *jsroot = cJSON_CreateObject();
+	// check arg
+	char arg_1_buf[16] = "";
+	int len;
+	bool get_app = true;  // get both app and data partitions by default
+	bool get_data = true;
+    len=httpdFindArg(connData->getArgs, "type", arg_1_buf, sizeof(arg_1_buf));
+    if (len > 0)
+    {
+    	if (strcmp(arg_1_buf, "app") == 0)
+    	{
+    		get_data = false;  // don't get data partitinos if client specified ?type=app
+    	}
+    	else if (strcmp(arg_1_buf, "data") == 0)
+    	{
+    		get_app = false;  // don't get app partitinos if client specified ?type=data
+    	}
+    }
 
-	//// Generate the header
-	//We want the header to start with HTTP code 200, which means the document is found.
-	httpdStartResponse(connData, 200);
-	httpdHeader(connData, "Cache-Control", "no-store, must-revalidate, no-cache, max-age=0");
-	httpdHeader(connData, "Expires", "Mon, 01 Jan 1990 00:00:00 GMT");  //  This one might be redundant, since modern browsers look for "Cache-Control".
-	httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
-	httpdEndHeaders(connData);
+    if (get_app)
+    {
+    	boot_partition = esp_ota_get_boot_partition();
+    	running_partition = esp_ota_get_running_partition();
+    	cJSON *jsapps = cJSON_AddArrayToObject(jsroot, "app");
+    	esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, NULL);
+        while (it != NULL) {
+            const esp_partition_t *it_partition = esp_partition_get(it);
+    		if (it_partition != NULL)
+    		{
+    			cJSON *partj = NULL;
+    			partj = cJSON_CreateObject();
+    			cJSON_AddStringToObject(partj, "name", it_partition->label);
+    			cJSON_AddNumberToObject(partj, "size", it_partition->size);
+    			cJSON_AddStringToObject(partj, "version", "");  // todo
+    			cJSON_AddBoolToObject(partj, "ota", PARTITION_IS_OTA(it_partition));
+    			cJSON_AddBoolToObject(partj, "valid", PARTITION_IS_FACTORY(it_partition)||(PARTITION_IS_OTA(it_partition) && check_partition_valid_app(it_partition)));  //lazy, only check OTA partitions
+    			cJSON_AddBoolToObject(partj, "running", (it_partition==running_partition));
+    			cJSON_AddBoolToObject(partj, "bootset", (it_partition==boot_partition));
+    			cJSON_AddItemToArray(jsapps, partj);
+    			it = esp_partition_next(it);
+    		}
+        }
+    	esp_partition_iterator_release(it);
+    }
 
-	for (it = 0; it < (sizeof(subtypes)/sizeof(subtypes[0])); it++)
+	if (get_data)
 	{
-		it_partition = esp_partition_find_first(ESP_PARTITION_TYPE_APP,subtypes[it],NULL);
-		if (it_partition != NULL)
-		{
-			cJSON *partj = NULL;
-			partj = cJSON_CreateObject();
-			cJSON_AddStringToObject(partj, "name", it_partition->label);
-			cJSON_AddNumberToObject(partj, "size", it_partition->size);
-			cJSON_AddStringToObject(partj, "version", "");  // todo
-			cJSON_AddBoolToObject(partj, "ota", (it_partition->subtype >= ESP_PARTITION_SUBTYPE_APP_OTA_MIN)&&(it_partition->subtype <= ESP_PARTITION_SUBTYPE_APP_OTA_MAX));
-			cJSON_AddBoolToObject(partj, "valid", true); // todo
-			cJSON_AddBoolToObject(partj, "running", (it_partition==running_partition));
-			cJSON_AddBoolToObject(partj, "bootset", (it_partition==boot_partition));
-			cJSON_AddItemToArray(root, partj);
-		}
+		cJSON *jsdatas = cJSON_AddArrayToObject(jsroot, "data");
+		esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, NULL);
+	    while (it != NULL) {
+	        const esp_partition_t *it_partition = esp_partition_get(it);
+			if (it_partition != NULL)
+			{
+				cJSON *partj = NULL;
+				partj = cJSON_CreateObject();
+				cJSON_AddStringToObject(partj, "name", it_partition->label);
+				cJSON_AddNumberToObject(partj, "size", it_partition->size);
+				cJSON_AddNumberToObject(partj, "format", it_partition->subtype);
+				cJSON_AddItemToArray(jsdatas, partj);
+				it = esp_partition_next(it);
+			}
+	    }
+		esp_partition_iterator_release(it);
 	}
 
-	json_string = cJSON_Print(root);
-    if (json_string)
-    {
-    	httpdSend(connData, json_string, -1);
-        cJSON_free(json_string);
-    }
-    cJSON_Delete(root);
-
+	cgiJsonResponseCommon(connData, jsroot); // Send the json response!
 	return HTTPD_CGI_DONE;
 }


### PR DESCRIPTION
I made some additions/improvements to the cgiFlash.c and improved the html/js GUI for managing partitions.
I'm not bothering to support the older ESP8266 chip (I don't have one).

Tested on:

*    ESP32-EVB from Olimex (ESP-WROOM-32 module, 4M flash)
*    Custom board with ESP32-WROVER (with 16M flash, 4.5M ram)

Note these additions complement my additions to the esphttpd-freertos repository.

The API is documented here:
https://github.com/phatpaul/libesphttpd/blob/master/README-flash_api.md

BTW, I'm compressing with yui-compressor and it's working OK.
* I can't seem to call java from inside the SDK, but I hacked it by copy java.exe from the jre install directory ("C:\Program Files\Java\jre1.8.0_181\bin\java.exe") to inside the SDK at /home/username/Tools/.  
* Copy yuicompressor-2.4.8.jar from https://github.com/yui/yuicompressor/releases to /home/username/Tools/
* Enable the option ESPHTTPD_USEYUICOMPRESSOR in menuconfig
* Can you find a cleaner way to do this?
* I would really like to use "webpack" https://webpack.js.org/ but it has been giving me trouble, probably because the version of node.js in the SDK is old.