### PR TITLE
improvements and bug-fixes to VFS cgi functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ the ESP8266/ESP32.
 
 * __cgiWiFi* functions__ (arg: various)
 These are used to change WiFi mode, scan for access points, associate to an access point etcetera. See
-the example projects for an implementation that uses these function calls.
+the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
 
 * __cgiWebsocket__ (arg: connect function)
-This CGI is used to set up a websocket. Websockets are described later in this document.
+This CGI is used to set up a websocket. Websockets are described later in this document.  See
+the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
 
 * __cgiEspFsHook__ (arg: none)
 Serves files from the espfs filesystem. The espFsInit function should be called first, with as argument
@@ -119,6 +120,37 @@ configured to do either.
 * __cgiEspFsTemplate__ (arg: template function)
 The espfs code comes with a small but efficient template routine, which can fill a template file stored on
 the espfs filesystem with user-defined data.
+
+* __cgiEspVfsGet__ (arg: base filesystem path)
+This is a catch-all cgi function. It takes the url passed to it, looks up the corresponding path in the filesystem and if it exists, sends the file. This simulates what a normal webserver would do with static files.  If the file is not found, (or if http method is not GET) this cgi function returns NOT_FOUND, and then other cgi functions specified later in the routing table can try.  See the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
+
+  The cgiArg value is the base directory path, if specified.
+  Usage:
+    * ROUTE_CGI("*", cgiEspVfsGet)
+    * ROUTE_CGI_ARG("*", cgiEspVfsGet, "/base/directory/")
+    * ROUTE_CGI_ARG("*", cgiEspVfsGet, ".") to use the current working directory
+    
+* __cgiEspVfsUpload__ (arg: base filesystem path)
+This is a POST and PUT handler for uploading files to the VFS filesystem.  See the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
+
+  Specify base directory (with trailing slash) or single file as 1st cgiArg.
+  If http method is not PUT or POST, this cgi function returns NOT_FOUND, and then other cgi functions specified later in the routing table can try.
+  
+  Filename can be specified 3 ways, in order of priority lowest to highest:
+  1. ___URL Path___  i.e. PUT http://1.2.3.4/path/newfile.txt
+  2. ___Inside multipart/form-data___ (todo not supported yet)
+  3. ___URL Parameter___  i.e. POST http://1.2.3.4/upload.cgi?filename=path%2Fnewfile.txt
+  
+  Usage:
+    * ROUTE_CGI_ARG("*", cgiEspVfsUpload, "/base/directory/")
+      - Allows creating/replacing files anywhere under "/base/directory/".  Don't forget to specify trailing slash in cgiArg!
+      - example: POST or PUT http://1.2.3.4/anydir/anyname.txt
+    * ROUTE_CGI_ARG("/filesystem/upload.cgi", cgiEspVfsUpload, "/base/directory/")
+      - Allows creating/replacing files anywhere under "/base/directory/".  Don't forget to specify trailing slash in cgiArg!
+      - example: POST or PUT http://1.2.3.4/filesystem/upload.cgi?filename=newdir%2Fnewfile.txt
+    * ROUTE_CGI_ARG("/writeable_file.txt", cgiEspVfsUpload, "/base/directory/writeable_file.txt")
+      - Allows only replacing content of one file at "/base/directory/writeable_file.txt".
+      - example: POST or PUT http://1.2.3.4/writeable_file.txt
 
 ## How to configure and use SSL
 

--- a/include/libesphttpd/esp32_httpd_vfs.h
+++ b/include/libesphttpd/esp32_httpd_vfs.h
@@ -1,13 +1,42 @@
-#pragma once
+#ifndef ESP32_HTTPD_VFS_H
+#define ESP32_HTTPD_VFS_H
+
+#include "httpd.h"
 
 //This is a catch-all cgi function. It takes the url passed to it, looks up the corresponding
 //path in the filesystem and if it exists, passes the file through. This simulates what a normal
 //webserver would do with static files.
-//
+// If the file is not found, (or if http method is not GET) this cgi function returns NOT_FOUND, and then other cgi functions specified later in the routing table can try.
 // The cgiArg value is the base directory path, if specified.
 //
 // Usage:
-//      ROUTE_CGI("*", cgiEspVfsHook) or
-//      ROUTE_CGI_ARG("*", cgiEspVfsHook, "/base/directory/") or
-//      ROUTE_CGI_ARG("*", cgiEspVfsHook, ".") to use the current working directory
-CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData);
+//      ROUTE_CGI("*", cgiEspVfsGet) or
+//      ROUTE_CGI_ARG("*", cgiEspVfsGet, "/base/directory/") or
+//      ROUTE_CGI_ARG("*", cgiEspVfsGet, ".") to use the current working directory
+CgiStatus cgiEspVfsGet(HttpdConnData *connData);
+
+
+//This is a POST and PUT handler for uploading files to the VFS filesystem.
+// If http method is not PUT or POST, this cgi function returns NOT_FOUND, and then other cgi functions specified later in the routing table can try.
+// Specify base directory (with trailing slash) or single file as 1st cgiArg.
+//
+// Filename can be specified 3 ways, in order of priority lowest to highest:
+//  1.  URL Path.  i.e. PUT http://1.2.3.4/path/newfile.txt
+//  2.  Inside multipart/form-data (todo not supported yet)
+//  3.  URL Parameter.  i.e. POST http://1.2.3.4/upload.cgi?filename=path%2Fnewfile.txt
+//
+// Usage:
+//      ROUTE_CGI_ARG("*", cgiEspVfsUpload, "/base/directory/")
+//           - Allows creating/replacing files anywhere under "/base/directory/".  Don't forget to specify trailing slash in cgiArg!
+//           - example: POST or PUT http://1.2.3.4/anydir/anyname.txt
+//
+//      ROUTE_CGI_ARG("/filesystem/upload.cgi", cgiEspVfsUpload, "/base/directory/")
+//           - Allows creating/replacing files anywhere under "/base/directory/".  Don't forget to specify trailing slash in cgiArg!
+//           - example: POST or PUT http://1.2.3.4/filesystem/upload.cgi?filename=newdir%2Fnewfile.txt
+//
+//      ROUTE_CGI_ARG("/writeable_file.txt", cgiEspVfsUpload, "/base/directory/writeable_file.txt")
+//           - Allows only replacing content of one file at "/base/directory/writeable_file.txt".
+//           - example: POST or PUT http://1.2.3.4/writeable_file.txt
+CgiStatus cgiEspVfsUpload(HttpdConnData *connData);
+
+#endif //ESP32_HTTPD_VFS_H

--- a/util/esp32_httpd_vfs.c
+++ b/util/esp32_httpd_vfs.c
@@ -5,21 +5,44 @@
 /*
 Connector to let httpd use the vfs filesystem to serve the files in it.
 */
-#include <unistd.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/unistd.h>
 #include <sys/stat.h>
+#include <sys/errno.h>
+#include "esp_err.h"
 #include "esp_log.h"
 #include "libesphttpd/esp.h"
 #include "libesphttpd/httpd.h"
+#include "httpd-platform.h"
+#include "cJSON.h"
 
-#define FILE_CHUNK_LEN    1024
+#define FILE_CHUNK_LEN    (1024)
+#define MAX_FILENAME_LENGTH (1024)
 
 // If the client does not advertise that he accepts GZIP send following warning message (telnet users for e.g.)
 static const char *gzipNonSupportedMessage = "HTTP/1.0 501 Not implemented\r\nServer: esp8266-httpd/"HTTPDVER"\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: 52\r\n\r\nYour browser does not accept gzip-compressed data.\r\n";
 
-static const int MAX_FILENAME_LENGTH = 1024;
+static void cgiJsonResponseCommon(HttpdConnData *connData, cJSON *jsroot){
+	char *json_string = NULL;
 
-CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData) {
+	//// Generate the header
+	//We want the header to start with HTTP code 200, which means the document is found.
+	httpdStartResponse(connData, 200);
+	httpdHeader(connData, "Cache-Control", "no-store, must-revalidate, no-cache, max-age=0");
+	httpdHeader(connData, "Expires", "Mon, 01 Jan 1990 00:00:00 GMT");  //  This one might be redundant, since modern browsers look for "Cache-Control".
+	httpdHeader(connData, "Content-Type", "application/json; charset=utf-8"); //We are going to send some JSON.
+	httpdEndHeaders(connData);
+	json_string = cJSON_Print(jsroot);
+    if (json_string)
+    {
+    	httpdSend(connData, json_string, -1);
+        cJSON_free(json_string);
+    }
+    cJSON_Delete(jsroot);
+}
+
+CgiStatus ICACHE_FLASH_ATTR cgiEspVfsGet(HttpdConnData *connData) {
 	FILE *file=connData->cgiData;
 	int len;
 	char buff[FILE_CHUNK_LEN];
@@ -33,19 +56,24 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData) {
 		//Connection aborted. Clean up.
 		if(file != NULL){
 			fclose(file);
+			ESP_LOGD(__func__, "fclose: %s, r", filename);
 		}
+		ESP_LOGE(__func__, "Connection aborted!");
 		return HTTPD_CGI_DONE;
 	}
 
 	//First call to this cgi.
 	if (file==NULL) {
+		if (connData->requestType!=HTTPD_METHOD_GET) {
+			return HTTPD_CGI_NOTFOUND;  //	return and allow another cgi function to handle it
+		}
 		filename[0] = '\0';
 
 		if (connData->cgiArg != NULL) {
 			strncpy(filename, connData->cgiArg, MAX_FILENAME_LENGTH);
 		}
 		strncat(filename, connData->url, MAX_FILENAME_LENGTH - strlen(filename));
-		ESP_LOGI(__func__, "GET: %s", filename);
+		ESP_LOGD(__func__, "GET: %s", filename);
 		
 		if(filename[strlen(filename)-1]=='/') filename[strlen(filename)-1]='\0';
 		if(stat(filename, &filestat) == 0) {
@@ -55,14 +83,16 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData) {
 		}
 
 		file = fopen(filename, "r");
+		if (file != NULL) ESP_LOGD(__func__, "fopen: %s, r", filename);
 		isGzip = 0;
 		
 		if (file==NULL) {
 			// Check if requested file is available GZIP compressed ie. with file extension .gz
 		
 			strncat(filename, ".gz", MAX_FILENAME_LENGTH - strlen(filename));
-			ESP_LOGI(__func__, "GET: GZIPped file - %s", filename);
+			ESP_LOGD(__func__, "GET: GZIPped file - %s", filename);
 			file = fopen(filename, "r");
+			if (file != NULL) ESP_LOGD(__func__, "fopen: %s, r", filename);
 			isGzip = 1;
 			
 			if (file==NULL) {
@@ -76,6 +106,8 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData) {
 				//No Accept-Encoding: gzip header present
 				httpdSend(connData, gzipNonSupportedMessage, -1);
 				fclose(file);
+				ESP_LOGD(__func__, "fclose: %s, r", filename);
+				ESP_LOGE(__func__, "client does not accept gzip!");
 				return HTTPD_CGI_DONE;
 			}
 		}
@@ -96,6 +128,8 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsHook(HttpdConnData *connData) {
 	if (len!=FILE_CHUNK_LEN) {
 		//We're done.
 		fclose(file);
+		ESP_LOGD(__func__, "fclose: %s, r", filename);
+
 		return HTTPD_CGI_DONE;
 	} else {
 		//Ok, till next time.
@@ -206,59 +240,209 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsTemplate(HttpdConnData *connData) {
 	}
 }
 
-CgiStatus   cgiEspVfsUpload(HttpdConnData *connData) {
-	FILE *file=connData->cgiData;
+static esp_err_t createMissingDirectories(char *fullpath) {
+	char *string, *tofree;
+	int err = ESP_OK;
+	tofree = string = strndup(fullpath, MAX_FILENAME_LENGTH); // make a copy because modifies input
+	assert(string != NULL);
+
+	int i;
+	for(i=0; string[i] != '\0'; i++) // search over all chars in fullpath
+	{
+		if (i>0 && (string[i] == '\\' || string[i] == '/')) // stop when reached a slash
+		{
+			struct stat sb;
+			char slash = string[i];
+			string[i] = '\0';  // replace slash with null terminator temporarily
+			if (stat(string, &sb) != 0) { // stat() will tell us if it is a file or directory or neither.
+				//printf("stat failed.\n");
+				if (errno == ENOENT)  /* No such file or directory */
+				{
+					// Create directory
+					int e = mkdir(string, S_IRWXU);
+					if (e != 0)
+					{
+						ESP_LOGE(__func__, "mkdir failed; errno=%d\n",errno);
+						err = ESP_FAIL;
+						break;
+					}
+					else
+					{
+						ESP_LOGI(__func__, "created the directory %s\n",string);
+					}
+				}
+		   }
+		   string[i] = slash; // replace the slash and keep searching fullpath
+	   }
+	}
+	free(tofree);  // don't skip this or memory-leak!
+	return err;
+}
+
+typedef struct {
+	enum {UPSTATE_START, UPSTATE_WRITE, UPSTATE_DONE, UPSTATE_ERR} state;
+	FILE *file;
 	char filename[MAX_FILENAME_LENGTH + 1];
-	char output[FILE_CHUNK_LEN];	//Temporary buffer for HTML output
-	int len;
+	int b_written;
+	const char *errtxt;
+} UploadState;
+
+CgiStatus   cgiEspVfsUpload(HttpdConnData *connData) {
+	UploadState *state=(UploadState *)connData->cgiData;
     
 	if (connData->isConnectionClosed) {
 		//Connection aborted. Clean up.
-		if(file != NULL){
-			fclose(file);
+		if (state != NULL)
+		{
+			if(state->file != NULL){
+				fclose(state->file);
+				ESP_LOGD(__func__, "fclose: %s, r", state->filename);
+			}
+			free(state);
 		}
+		ESP_LOGE(__func__, "Connection aborted!");
 		return HTTPD_CGI_DONE;
 	}
 
 	//First call to this cgi.
-	if (file==NULL) {
-		filename[0] = '\0';
-
-		if (connData->requestType!=HTTPD_METHOD_PUT) {
-			httpdStartResponse(connData, 405);  //http error code 'Method Not Allowed'
-			httpdEndHeaders(connData);
-			return HTTPD_CGI_DONE;
-		} else {
-			if(connData->cgiArg != NULL){
-				strncpy(filename, connData->cgiArg, MAX_FILENAME_LENGTH);
-			}
-
-			strncat(filename, "/", MAX_FILENAME_LENGTH - strlen(filename));
-			strncat(filename, connData->getArgs, MAX_FILENAME_LENGTH - strlen(filename));
-			ESP_LOGI(__func__, "Uploading: %s", filename);
-
-			file = fopen(filename, "w");
-			connData->cgiData = file;
+	if (state == NULL) {
+		if (!(connData->requestType==HTTPD_METHOD_PUT || connData->requestType==HTTPD_METHOD_POST)) {
+			return HTTPD_CGI_NOTFOUND;  //	return and allow another cgi function to handle it
 		}
+		//First call. Allocate and initialize state variable.
+		state = malloc(sizeof(UploadState));
+		if (state==NULL) {
+			ESP_LOGE(__func__, "Can't allocate upload struct");
+			//return HTTPD_CGI_NOTFOUND;  // Let cgiNotFound() deal with extra post data.
+			state->state=UPSTATE_ERR;
+			goto error_first;
+		}
+		memset(state, 0, sizeof(UploadState));  // all members of state are initialized to 0
+		state->state = UPSTATE_START;
+
+		if (connData->post.multipartBoundary != NULL)
+		{
+			// todo: handle when uploaded file is POSTed in a multipart/form-data.  For now, just upload the file by itself (i.e. xhr.send(file), not xhr.send(form)).
+			ESP_LOGE(__func__, "Sorry! file upload in multipart/form-data is not supported yet.");
+			//return HTTPD_CGI_NOTFOUND;  // Let cgiNotFound() deal with extra post data.
+			state->state=UPSTATE_ERR;
+			goto error_first;
+		}
+
+		// cgiArg specifies where this function is allowed to write to.  It must be specified and can't be empty.
+		const char *basePath = connData->cgiArg;
+		if ((basePath == NULL) || (*basePath == 0)) {
+			state->state=UPSTATE_ERR;
+			goto error_first;
+		}
+		int n = strlcpy(state->filename, basePath, MAX_FILENAME_LENGTH);
+		if (n >= MAX_FILENAME_LENGTH) goto error_first;
+
+		// Is cgiArg a single file or a directory (with trailing slash)?
+		if (basePath[n - 1] == '\\' || basePath[n - 1] == '/') // check last char in cgiArg string for a slash
+		{
+			// Last char of cgiArg is a slash, assume it is a directory.
+
+			// get queryParameter "filename" : string
+			char* filenamebuf = state->filename + n;
+		    int arglen = httpdFindArg(connData->getArgs, "filename", filenamebuf, MAX_FILENAME_LENGTH - n);
+		    // 3. (highest priority) Filename to write to is cgiArg + "filename" as specified by url parameter
+		    if (arglen > 0)
+		    {
+		    	// filename is already appended by httpdFindArg() above.
+		    }
+		    // 2. Filename to write to is cgiArg + "filename" as inside multipart/form-data --todo)
+		    else if (0)
+		    {
+				// Beginning of POST data (after first headers):
+				/*
+				-----------------------------190192493010810\r\n
+				Content-Disposition: form-data; name="file"; filename="/README.md"\r\n
+				Content-Type: application/octet-stream\r\n
+				\r\n
+				datadatadatadata...
+	            */
+		    }
+		    // 1: Filename to write to is cgiArg + url.
+		    else if(connData->url != NULL){
+				strncat(state->filename, connData->url, MAX_FILENAME_LENGTH - n);
+			}
+		}
+		else
+		{
+			// Last char of cgiArg is not a slash, assume a single file.
+			// Filename to write to is forced to cgiArg.  The filename specified in the PUT url or in the POST filename is simply ignored.
+			//   (Anyway, a proper ROUTE entry should enforce the PUT url matches the cgiArg. i.e.
+			//   ROUTE_CGI_ARG("/writeable_file.txt", cgiEspVfsPut, FS_BASE_PATH "/html/writeable_file.txt"))
+			// filename is already = basePath from strlcpy() above.
+		}
+
+
+		ESP_LOGI(__func__, "Uploading: %s", state->filename);
+
+		// Create missing directories
+		if (createMissingDirectories(state->filename) != ESP_OK)
+		{
+			state->errtxt="Error creating directory!";
+			state->state=UPSTATE_ERR;
+			goto error_first;
+		}
+
+		// Open file for writing
+		state->file = fopen(state->filename, "w");
+		if (state->file == NULL)
+		{
+			ESP_LOGE(__func__, "Can't open file for writing!");
+			state->errtxt="Can't open file for writing!";
+			state->state=UPSTATE_ERR;
+			goto error_first;
+		}
+
+		state->state=UPSTATE_WRITE;
+		ESP_LOGD(__func__, "fopen: %s, w", state->filename);
+
+error_first:
+		connData->cgiData=state;
 	}
 
-	ESP_LOGI(__func__, "Chunk: %d bytes, ", connData->post.buffLen);
-	fwrite(connData->post.buff, 1, connData->post.buffLen, file);
-	//todo: error check that bytes written == bufLen etc...
+	ESP_LOGD(__func__, "Chunk: %d bytes, ", connData->post.buffLen);
+
+	if (state->state==UPSTATE_WRITE) {
+		if(state->file != NULL){
+			int count = fwrite(connData->post.buff, 1, connData->post.buffLen, state->file);
+			state->b_written += count;
+			if (count != connData->post.buffLen)
+			{
+				state->state=UPSTATE_ERR;
+				ESP_LOGE(__func__, "error writing to filesystem!");
+			}
+			if (state->b_written >= connData->post.len){
+				state->state=UPSTATE_DONE;
+			}
+		} // else, Just eat up any bytes we receive.
+	} else if (state->state==UPSTATE_DONE) {
+		ESP_LOGE(__func__, "bogus bytes received after data received");
+		//Ignore those bytes.
+	} else if (state->state==UPSTATE_ERR) {
+		//Just eat up any bytes we receive.
+	}
+
 	if (connData->post.received == connData->post.len) {
 		//We're done.
-		fclose(file);
-		ESP_LOGI(__func__, "Total: %d bytes written, ", connData->post.received);
-		httpdStartResponse(connData, 200);
-		httpdHeader(connData, "Content-Type", "application/json");
-		httpdEndHeaders(connData);
+		cJSON *jsroot = cJSON_CreateObject();
+		if(state->file != NULL){
+			fclose(state->file);
+			ESP_LOGD(__func__, "fclose: %s, r", state->filename);
+		}
+		ESP_LOGI(__func__, "Total: %d bytes written.", state->b_written);
 
-		httpdSend(connData, "{", -1);
-		len = snprintf(output, FILE_CHUNK_LEN, "\"filename\": \"%s/%s\", ", (char *) connData->cgiArg, (char *) connData->getArgs);
-		httpdSend(connData, output, len);
-		len = snprintf(output, FILE_CHUNK_LEN, "\"size\": \"%d\" ", connData->post.received);
-		httpdSend(connData, output, len);
-		httpdSend(connData, "}", -1);
+		cJSON_AddStringToObject(jsroot, "filename", state->filename);
+		cJSON_AddNumberToObject(jsroot, "bytes received", connData->post.received);
+		cJSON_AddNumberToObject(jsroot, "bytes written", state->b_written);
+		cJSON_AddBoolToObject(jsroot, "success", state->state==UPSTATE_DONE);
+		free(state);
+
+		cgiJsonResponseCommon(connData, jsroot); // Send the json response!
 		return HTTPD_CGI_DONE;
 	} else {
 		//Ok, till next time.


### PR DESCRIPTION
Improvements and bug-fixes to VFS cgi functions.  

Added POST handling to vfs_upload function.  (File should be posted by itself - file embedded inside a multipart/form-data is not implemented yet.  I asked @PaulFreund for help with this, since I don't need it for my project and he has said he already implemented it: https://github.com/chmorgan/libesphttpd/pull/40#issuecomment-431839419)

Added filename specification via URL, or parameter, (or inside post data -todo).

Added create missing directories.

Added json response.

Added documentation.

I'll create a PR for the FreeRToS example project as well.