### PR TITLE
Added error message to cgiWebsocketSend

### DIFF
--- a/include/libesphttpd/cgiwebsocket.h
+++ b/include/libesphttpd/cgiwebsocket.h
@@ -7,7 +7,7 @@
 #define WEBSOCK_FLAG_MORE (1<<0) //Set if the data is not the final data in the message; more follows
 #define WEBSOCK_FLAG_BIN (1<<1) //Set if the data is binary instead of text
 #define WEBSOCK_FLAG_CONT (1<<2) //set if this is a continuation frame (after WEBSOCK_FLAG_CONT)
-
+#define WEBSOCK_CLOSED -1
 
 typedef struct Websock Websock;
 typedef struct WebsockPriv WebsockPriv;

--- a/util/cgiwebsocket.c
+++ b/util/cgiwebsocket.c
@@ -124,6 +124,11 @@ int ICACHE_FLASH_ATTR cgiWebsocketSend(HttpdInstance *pInstance, Websock *ws, co
 	// add FIN to last frame
 	if (!(flags&WEBSOCK_FLAG_MORE)) fl|=FLAG_FIN;
 
+    if (ws->conn->isConnectionClosed) {
+        ESP_LOGE(TAG, "Websocket closed, cannot send");
+        return WEBSOCK_CLOSED;
+    }
+
 	sendFrameHead(ws, fl, len);
 	if (len!=0) r=httpdSend(ws->conn, data, len);
 	httpdFlushSendBuffer(pInstance, ws->conn);


### PR DESCRIPTION
Print error message and return error value if user attempts to call cgiWebsocketSend on a closed websocket connection.