### PR TITLE
Surrounded C methods with 'extern "C"' to make them usable from C++ code

### DIFF
--- a/include/libesphttpd/cgiwebsocket.h
+++ b/include/libesphttpd/cgiwebsocket.h
@@ -9,6 +9,10 @@
 #define WEBSOCK_FLAG_CONT (1<<2) //set if this is a continuation frame (after WEBSOCK_FLAG_CONT)
 #define WEBSOCK_CLOSED -1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct Websock Websock;
 typedef struct WebsockPriv WebsockPriv;
 
@@ -33,5 +37,8 @@ void ICACHE_FLASH_ATTR cgiWebsocketClose(HttpdInstance *pInstance, Websock *ws, 
 CgiStatus ICACHE_FLASH_ATTR cgiWebSocketRecv(HttpdInstance *pInstance, HttpdConnData *connData, char *data, int len);
 int ICACHE_FLASH_ATTR cgiWebsockBroadcast(HttpdInstance *pInstance, const char *resource, char *data, int len, int flags);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/include/libesphttpd/httpd-espfs.h
+++ b/include/libesphttpd/httpd-espfs.h
@@ -7,6 +7,10 @@
 #include <libesphttpd/esp.h>  // for sdkconfig.h
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef CONFIG_ESPHTTPD_USE_ESPFS
 #include "httpd.h"
 /**
@@ -24,5 +28,9 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData);
 int tplSend(HttpdConnData *conn, const char *str, int len);
 
 #endif // CONFIG_ESPHTTPD_USE_ESPFS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif // HTTPDESPFS_H

--- a/include/libesphttpd/httpd-freertos.h
+++ b/include/libesphttpd/httpd-freertos.h
@@ -28,6 +28,10 @@
     #define PLAT_RETURN void
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct RtosConnType{
 	int fd;
 	int needWriteDoneNotif;
@@ -182,3 +186,6 @@ void httpdFreertosSslSetClientValidation(HttpdFreertosInstance *pInstance,
  */
 void httpdFreertosSslAddClientCertificate(HttpdFreertosInstance *pInstance,
                                           const void *certificate, size_t certificate_size);
+#ifdef __cplusplus
+} /* extern "C" */
+#endif


### PR DESCRIPTION
Hello. Please consider merging this minor change. It will make some of the capabilities usable form within C++ code. Thanks