### PR TITLE
File buffer on heap

### DIFF
--- a/util/esp32_httpd_vfs.c
+++ b/util/esp32_httpd_vfs.c
@@ -45,7 +45,6 @@ static void cgiJsonResponseCommon(HttpdConnData *connData, cJSON *jsroot){
 CgiStatus ICACHE_FLASH_ATTR cgiEspVfsGet(HttpdConnData *connData) {
 	FILE *file=connData->cgiData;
 	int len;
-	char buff[FILE_CHUNK_LEN];
 	char filename[MAX_FILENAME_LENGTH + 1];
 	char acceptEncodingBuffer[64];
 	int isGzip;
@@ -123,8 +122,10 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsGet(HttpdConnData *connData) {
 		return HTTPD_CGI_MORE;
 	}
 
+	char *buff = malloc(FILE_CHUNK_LEN);
 	len=fread(buff, 1, FILE_CHUNK_LEN, file);
 	if (len>0) httpdSend(connData, buff, len);
+	free(buff);
 	if (len!=FILE_CHUNK_LEN) {
 		//We're done.
 		fclose(file);


### PR DESCRIPTION
Hello. Please consider merging this pull request.

When serving very large files, or a large number of files, the current implementation experiences stack overflow failures. This change allocates the needed buffer on the heap rather than on the stack, and only allocates the buffer if/when needed right before the read and send operation. The change made it possible for me to serve significantly larger files (tested up to 15 2MB files being served simultaneously, which consistently failed before the change).