### PR TITLE
added the "PUT" method to CORS header Access-Control-Allow-Metho…

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -240,7 +240,7 @@ void ICACHE_FLASH_ATTR httpdStartResponse(HttpdConnData *conn, int code) {
 #ifdef CONFIG_ESPHTTPD_CORS_SUPPORT
     // CORS headers
     httpdSend(conn, "Access-Control-Allow-Origin: *\r\n", -1);
-    httpdSend(conn, "Access-Control-Allow-Methods: GET,POST,DELETE,OPTIONS\r\n", -1);
+    httpdSend(conn, "Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS\r\n", -1);
 #endif
 }
 


### PR DESCRIPTION
Not sure why PUT was not included in allowed methods for CORS.  I needed it for my application, so here it is added.  

It tested OK for me.

FYI:
https://stackoverflow.com/questions/44914330/method-put-is-not-allowed-by-access-control-allow-methods-in-preflight-response
