### PR TITLE
HttpCgiExArg: better handling of CgiArg/CgiArg2 arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,23 @@ the example projects for an implementation that uses this function call.  [FreeR
 This CGI is used to set up a websocket. Websockets are described later in this document.  See
 the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
 
-* __cgiEspFsHook__ (arg: none)
+* __cgiEspFsHook__ (arg1: basepath or &httpdCgiEx magic, arg2:HttpdCgiExArg struct if arg1 was &httpdCgiEx)
 Serves files from the espfs filesystem. The espFsInit function should be called first, with as argument
 a pointer to the start of the espfs binary data in flash. The binary data can be both flashed separately
 to a free bit of SPI flash, as well as linked in with the binary. The nonos example project can be
 configured to do either.
 
+  If arg1 is supplied &httpdCgiEx Magic value, then arg2 is assumed to be of type HttpdCgiExArg, which is a stuct containing extended options.  This should allow for future addition of custom parameters without breaking existing cgi functions that make use of existing members of this struct.
+  Currently available options are: 
+   - basepath: base directory path on filesystem  (Optional, uses URL if NULL)
+   - headerCb: pointer to function which supplies custom headers.  (Optional, sends default headers if NULL)
+   - mimetype: customize the MIMETYPE  (Optional, sends default MIMETYPE if NULL)
+
 * __cgiEspFsTemplate__ (arg: template function)
 The espfs code comes with a small but efficient template routine, which can fill a template file stored on
 the espfs filesystem with user-defined data.
 
-* __cgiEspVfsGet__ (arg: base filesystem path)
+* __cgiEspVfsGet__ (arg1: basepath or &httpdCgiEx magic, arg2:HttpdCgiExArg struct if arg1 was &httpdCgiEx)
 This is a catch-all cgi function. It takes the url passed to it, looks up the corresponding path in the filesystem and if it exists, sends the file. This simulates what a normal webserver would do with static files.  If the file is not found, (or if http method is not GET) this cgi function returns NOT_FOUND, and then other cgi functions specified later in the routing table can try.  See the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)
 
   The cgiArg value is the base directory path, if specified.
@@ -129,6 +135,8 @@ This is a catch-all cgi function. It takes the url passed to it, looks up the co
     * ROUTE_CGI("*", cgiEspVfsGet)
     * ROUTE_CGI_ARG("*", cgiEspVfsGet, "/base/directory/")
     * ROUTE_CGI_ARG("*", cgiEspVfsGet, ".") to use the current working directory
+
+  Alternatively, if cgiArg is &httpdCgiEx Magic value, see section about HttpdCgiExArg in item __cgiEspFsHook__ above.
     
 * __cgiEspVfsUpload__ (arg: base filesystem path)
 This is a POST and PUT handler for uploading files to the VFS filesystem.  See the example projects for an implementation that uses this function call.  [FreeRTOS Example](https://github.com/chmorgan/esphttpd-freertos)

--- a/core/httpd-espfs.c
+++ b/core/httpd-espfs.c
@@ -216,8 +216,8 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 	}
 	if (connData->cgiArg != &httpdCgiEx) {
 		filepath[0] = '\0';
-		if (connData->cgiArg != NULL) {
-			outlen = strlcpy(filepath, connData->cgiArg, len);
+		if (connData->cgiArg2 != NULL) {
+			outlen = strlcpy(filepath, connData->cgiArg2, len);
 			if (espFsStat(espfs, filepath, &s) == 0 && s.type == ESPFS_TYPE_FILE) {
 				return outlen;
 			}

--- a/core/httpd-espfs.c
+++ b/core/httpd-espfs.c
@@ -209,7 +209,11 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 {
 	EspFsStat s;
 	int outlen;
-
+	if (!espfs)
+	{
+		ESP_LOGE(TAG, "espfs not registered");
+		return NULL;
+	}
 	if (connData->cgiArg != &httpdCgiEx) {
 		filepath[0] = '\0';
 		if (connData->cgiArg != NULL) {
@@ -229,8 +233,11 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 		url++;
 	}
 
-	size_t basepathLen = strlen(ex->basepath);
-	if (!ex->basepath || basepathLen == 0) {
+	size_t basepathLen = 0;
+	if (ex->basepath) {
+		basepathLen = strlen(ex->basepath);
+	}
+	if (basepathLen == 0) {
 		return strlcpy(filepath, url, len);
 	}
 

--- a/core/httpd-espfs.c
+++ b/core/httpd-espfs.c
@@ -216,8 +216,8 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 	}
 	if (connData->cgiArg != &httpdCgiEx) {
 		filepath[0] = '\0';
-		if (connData->cgiArg2 != NULL) {
-			outlen = strlcpy(filepath, connData->cgiArg2, len);
+		if (connData->cgiArg != NULL) {
+			outlen = strlcpy(filepath, connData->cgiArg, len);
 			if (espFsStat(espfs, filepath, &s) == 0 && s.type == ESPFS_TYPE_FILE) {
 				return outlen;
 			}
@@ -316,7 +316,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 
 	if (connData->isConnectionClosed) {
 		//Connection aborted. Clean up.
-		((TplCallback)(connData->cgiArg))(connData, NULL, &tpd->tplArg);
+		((TplCallback)(connData->cgiArg2))(connData, NULL, &tpd->tplArg);
 		espFsClose(tpd->file);
 		free(tpd);
 		return HTTPD_CGI_DONE;
@@ -467,7 +467,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 
 						tpd->chunk_resume = false;
 
-						CgiStatus status = ((TplCallback)(connData->cgiArg))(connData, tpd->token, &tpd->tplArg);
+						CgiStatus status = ((TplCallback)(connData->cgiArg2))(connData, tpd->token, &tpd->tplArg);
 						if (status == HTTPD_CGI_MORE) {
 //							espfs_dbg("Multi-part tpl subst, saving parser state");
 							// wants to send more in this token's place.....
@@ -522,7 +522,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 	if (sp!=0) httpdSend(connData, e, sp);
 	if (len!=FILE_CHUNK_LEN) {
 		//We're done.
-		((TplCallback)(connData->cgiArg))(connData, NULL, &tpd->tplArg);
+		((TplCallback)(connData->cgiArg2))(connData, NULL, &tpd->tplArg);
 		ESP_LOGD(TAG, "Template sent");
 		espFsClose(tpd->file);
 		free(tpd);

--- a/core/httpd.c
+++ b/core/httpd.c
@@ -40,6 +40,9 @@ typedef struct {
 } MimeMap;
 
 
+const char *httpdCgiEx = "HttpdCgiExArg";
+
+
 //#define RSTR(a) ((const char)(a))
 
 //The mappings from file extensions to mime types. If you need an extra mime type,
@@ -593,6 +596,7 @@ static void ICACHE_FLASH_ATTR httpdProcessRequest(HttpdInstance *pInstance, Http
 
             if (match) {
                 ESP_LOGD(TAG, "Is url index %d", i);
+                conn->route=route;
                 conn->cgiData=NULL;
                 conn->cgi=pUrl->cgiCb;
                 conn->cgiArg=pUrl->cgiArg;

--- a/core/httpd.c
+++ b/core/httpd.c
@@ -33,14 +33,14 @@ const static char* TAG = "httpd";
 #define HFL_NOCONNECTIONSTR (1<<4)
 
 
+const char *httpdCgiEx = "HttpdCgiExArg";
+
+
 //Struct to keep extension->mime data in
 typedef struct {
     const char *ext;
     const char *mimetype;
 } MimeMap;
-
-
-const char *httpdCgiEx = "HttpdCgiExArg";
 
 
 //#define RSTR(a) ((const char)(a))

--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -124,6 +124,7 @@ struct HttpdPostData {
 struct HttpdConnData {
 	RequestTypes requestType;
 	char *url;				// The URL requested, without hostname or GET arguments
+	const char *route;		// The route matched.
 	char *getArgs;			// The GET arguments for this request, if any.
 	const void *cgiArg;		// Argument to the CGI function, as stated as the 3rd argument of
 							// the builtInUrls entry that referred to the CGI function.
@@ -145,6 +146,13 @@ typedef struct {
 	const void *cgiArg;
 	const void *cgiArg2;
 } HttpdBuiltInUrl;
+
+const char *httpdCgiEx;  /* Magic for use in CgiArgs to interpret CgiArgs2 as HttpdCgiExArg */
+
+typedef struct {
+	void (*headerCb)(HttpdConnData *connData);
+	const char *basePath;
+} HttpdCgiExArg;
 
 void httpdRedirect(HttpdConnData *conn, const char *newUrl);
 

--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -151,7 +151,8 @@ const char *httpdCgiEx;  /* Magic for use in CgiArgs to interpret CgiArgs2 as Ht
 
 typedef struct {
 	void (*headerCb)(HttpdConnData *connData);
-	const char *basePath;
+	const char *mimetype;
+	const char *basepath;
 } HttpdCgiExArg;
 
 void httpdRedirect(HttpdConnData *conn, const char *newUrl);

--- a/include/libesphttpd/route.h
+++ b/include/libesphttpd/route.h
@@ -23,10 +23,10 @@
 #define ROUTE_FILE_EX(path, ex)                    ROUTE_CGI_EX((path), cgiEspFsHook, (HttpdCgiExArg*)(ex))
 
 /** Static file as a template with a replacer function */
-#define ROUTE_TPL(path, replacer)                  ROUTE_CGI_ARG((path), cgiEspFsTemplate, (TplCallback)(replacer))
+#define ROUTE_TPL(path, replacer)                  ROUTE_CGI_ARG2((path), cgiEspFsTemplate, NULL, (TplCallback)(replacer))
 
 /** Static file as a template with a replacer function, taking additional argument connData->cgiArg2 */
-#define ROUTE_TPL_FILE(path, replacer, filepath)   ROUTE_CGI_ARG2((path), cgiEspFsTemplate, (TplCallback)(replacer), (filepath))
+#define ROUTE_TPL_FILE(path, replacer, filepath)   ROUTE_CGI_ARG2((path), cgiEspFsTemplate, (const char*)(filepath), (TplCallback)(replacer))
 
 /** Redirect to some URL */
 #define ROUTE_REDIRECT(path, target)               ROUTE_CGI_ARG((path), cgiRedirect, (const char*)(target))
@@ -38,6 +38,6 @@
 #define ROUTE_WS(path, callback)                   ROUTE_CGI_ARG((path), cgiWebsocket, (WsConnectedCb)(callback))
 
 /** Catch-all filesystem route */
-#define ROUTE_FILESYSTEM()                             ROUTE_CGI("*", cgiEspFsHook)
+#define ROUTE_FILESYSTEM()                         ROUTE_CGI("*", cgiEspFsHook)
 
 #define ROUTE_END() {NULL, NULL, NULL, NULL}

--- a/include/libesphttpd/route.h
+++ b/include/libesphttpd/route.h
@@ -7,14 +7,20 @@
 /** Route with a CGI handler and two arguments */
 #define ROUTE_CGI_ARG2(path, handler, arg1, arg2)  {(path), (handler), (void *)(arg1), (void *)(arg2)}
 
-/** Route with a CGI handler and one arguments */
+/** Route with a CGI handler and one argument */
 #define ROUTE_CGI_ARG(path, handler, arg1)         ROUTE_CGI_ARG2((path), (handler), (arg1), NULL)
+
+/** Route with a CGI handler and an extended argument */
+#define ROUTE_CGI_EX(path, handler, ex)            ROUTE_CGI_ARG2((path), (handler), &httpdCgiEx, (ex))
 
 /** Route with an argument-less CGI handler */
 #define ROUTE_CGI(path, handler)                   ROUTE_CGI_ARG2((path), (handler), NULL, NULL)
 
 /** Static file route (file loaded from espfs) */
 #define ROUTE_FILE(path, filepath)                 ROUTE_CGI_ARG((path), cgiEspFsHook, (const char*)(filepath))
+
+/** Extended static file route (file loaded from espfs) */
+#define ROUTE_FILE_EX(path, ex)                    ROUTE_CGI_EX((path), cgiEspFsHook, (HttpdCgiExArg*)(ex))
 
 /** Static file as a template with a replacer function */
 #define ROUTE_TPL(path, replacer)                  ROUTE_CGI_ARG((path), cgiEspFsTemplate, (TplCallback)(replacer))

--- a/util/esp32_httpd_vfs.c
+++ b/util/esp32_httpd_vfs.c
@@ -110,6 +110,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspVfsGet(HttpdConnData *connData) {
 
 	//First call to this cgi.
 	if (file==NULL) {
+		isGzip = 0;
 		if (connData->requestType!=HTTPD_METHOD_GET) {
 			return HTTPD_CGI_NOTFOUND;  //	return and allow another cgi function to handle it
 		}


### PR DESCRIPTION
This allows routes like "/vfs/*" to map to "/spiffs/" instead of "/spiffs/vfs/" when cgiArg2 is a true value.