### PR TITLE
Avoid blocking the server on a request with exceedingly long headers

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -815,6 +815,8 @@ CallbackStatus ICACHE_FLASH_ATTR httpdRecvCb(HttpdInstance *pInstance, HttpdConn
                 } else
                 {
                     ESP_LOGE(TAG, "adding newline request too long");
+                    status = CallbackErrorMemory;
+                    break;
                 }
             }
 
@@ -825,6 +827,8 @@ CallbackStatus ICACHE_FLASH_ATTR httpdRecvCb(HttpdInstance *pInstance, HttpdConn
             } else
             {
                 ESP_LOGE(TAG, "request too long!");
+                status = CallbackErrorMemory;
+                break;
             }
 
             // always null terminate


### PR DESCRIPTION
During the parsing of HTTP headers the server enters an infinite loop if the request headers exceed `HTTPD_MAX_HEAD_LEN`. A simple `break` instruction suffices to abort the handling with a 500 error. 