### PR TITLE
Two old fixes

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -850,7 +850,7 @@ CallbackStatus ICACHE_FLASH_ATTR httpdRecvCb(HttpdInstance *pInstance, HttpdConn
                     httpdProcessRequest(pInstance, conn);
                 }
             }
-        } else if (conn->post.len!=0) {
+        } else if (conn->post.buff && conn->post.len!=0) {
             //This byte is a POST byte.
             conn->post.buff[conn->post.buffLen++]=data[x];
             conn->post.received++;


### PR DESCRIPTION
Hello all,
I've recently dug out these, which were originally made for esp8266(esp-open-rtos), to prevent that chip running out of memory. Since esp32 is much more stronger, these maybe useless.
Nevertheless, I'd like to share here for a reference. All were rebased to concurrent head.