### PR TITLE
Fixed rare malformed chunk encoding caused by filled up conn->sendBuff

### DIFF
--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -39,7 +39,12 @@ extern "C" {
 
 //Send buffer limit for httpdSend. 2 bytes are reserved for chunk termination ('\r\n').
 #ifndef HTTPD_SENDBUFF_MAX_FILL
-#define HTTPD_SENDBUFF_MAX_FILL	HTTPD_SENDBUFF_SIZE - 2
+#define HTTPD_SENDBUFF_MAX_FILL	(HTTPD_SENDBUFF_SIZE - 2)
+#endif
+
+//Send buffer limit (for backward compatibility
+#ifndef HTTPD_MAX_SENDBUFF_LEN
+#define HTTPD_MAX_SENDBUFF_LEN HTTPD_SENDBUFF_MAX_FILL
 #endif
 
 //If some data can't be sent because the underlaying socket doesn't accept the data (like the nonos

--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -37,6 +37,7 @@ extern "C" {
 #define HTTPD_SENDBUFF_SIZE	2048
 #endif
 
+//Send buffer limit for httpdSend. 2 bytes are reserved for chunk termination ('\r\n').
 #ifndef HTTPD_SENDBUFF_MAX_FILL
 #define HTTPD_SENDBUFF_MAX_FILL	HTTPD_SENDBUFF_SIZE - 2
 #endif

--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -32,9 +32,13 @@ extern "C" {
 #define HTTPD_MAX_POST_LEN		2048
 #endif
 
-//Max send buffer len
-#ifndef HTTPD_MAX_SENDBUFF_LEN
-#define HTTPD_MAX_SENDBUFF_LEN	2048
+//Send buffer size
+#ifndef HTTPD_SENDBUFF_SIZE
+#define HTTPD_SENDBUFF_SIZE	2048
+#endif
+
+#ifndef HTTPD_SENDBUFF_MAX_FILL
+#define HTTPD_SENDBUFF_MAX_FILL	HTTPD_SENDBUFF_SIZE - 2
 #endif
 
 //If some data can't be sent because the underlaying socket doesn't accept the data (like the nonos
@@ -96,7 +100,7 @@ struct HttpdPriv {
 	char corsToken[MAX_CORS_TOKEN_LEN];
 #endif
 	int headPos;
-	char sendBuff[HTTPD_MAX_SENDBUFF_LEN];
+	char sendBuff[HTTPD_SENDBUFF_SIZE];
 	int sendBuffLen;
 
 	/** NOTE: chunkHdr, if valid, points at memory assigned to sendBuff


### PR DESCRIPTION
This change should fix the bug with malformed chunks in HTTPD responses.
See #90 for more details.