### PR TITLE
Fix occasionally corrupted frameheader

### DIFF
--- a/core/httpd-freertos.c
+++ b/core/httpd-freertos.c
@@ -222,7 +222,10 @@ void platHttpServerTaskInit(ServerTaskContext *ctx, HttpdFreertosInstance *pInst
     ctx->pInstance = pInstance;
 
 #ifdef linux
-    pthread_mutex_init(&ctx->pInstance->httpdMux, NULL);
+    pthread_mutexattr_t mutexattr;
+    pthread_mutexattr_init(&mutexattr);
+    pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&ctx->pInstance->httpdMux, &mutexattr);
 #else
     ctx->pInstance->httpdMux = xSemaphoreCreateRecursiveMutex();
 #endif


### PR DESCRIPTION
Lock sendBuff whenever the server sends something to the client so frames don't get written to the wrong position in the buffer. Caution: Functions cgiWebsocketSend() & cgiWebsocketClose() now possibly block.
Fixes issue #84