### PR TITLE
Fix invalid accesses may occur under stress

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -854,7 +854,7 @@ CallbackStatus ICACHE_FLASH_ATTR httpdRecvCb(HttpdInstance *pInstance, HttpdConn
                     httpdProcessRequest(pInstance, conn);
                 }
             }
-        } else if (conn->post.len!=0) {
+        } else if (conn->post.buff && conn->post.len!=0) {
             //This byte is a POST byte.
             conn->post.buff[conn->post.buffLen++]=data[x];
             conn->post.received++;


### PR DESCRIPTION
malloc() on post.buff may return null, but nothing e.g. flags will indicate this. Then a violate access happen.
I copied the change here since it seems @meowthink deleted his branch and we want to merge only this part of https://github.com/chmorgan/libesphttpd/pull/89
