### PR TITLE
espfs: compatibility with `documentation` change

### DIFF
--- a/include/libesphttpd/httpd-espfs.h
+++ b/include/libesphttpd/httpd-espfs.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 #ifdef CONFIG_ESPHTTPD_USE_ESPFS
-#include "espfs.h"
+#include "libespfs/espfs.h"
 #include "httpd.h"
 /**
  * The template substitution callback.
@@ -20,7 +20,7 @@ extern "C" {
  */
 typedef CgiStatus (* TplCallback)(HttpdConnData *connData, char *token, void **arg);
 
-void httpdRegisterEspfs(EspFs *fs);
+void httpdRegisterEspfs(espfs_fs_t *fs);
 CgiStatus cgiEspFsHook(HttpdConnData *connData);
 CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData);
 


### PR DESCRIPTION
The API of espfs was changed with the commit numbered
[39ca280970e47b4dcc6081db460a3990e7b537aa ](https://github.com/jkent/libespfs/commit/39ca280970e47b4dcc6081db460a3990e7b537aa)(accompanied solely by the
message `documentation`). This change was pushed on 29 December 2020, so it's been around almost a full year.

This commit renames symbols to match the new names so that `libesphttpd` works with the current version of `libespfs`, as well as every release since `v1.0.0`.