### PR TITLE
fix memory leak in helper function cgiResponseCommonMulti()

### DIFF
--- a/util/cgi_common.c
+++ b/util/cgi_common.c
@@ -239,7 +239,7 @@ CgiStatus cgiResponseCommonMulti(HttpdConnData *connData, void **statepp, char *
 	// if called without state pointer (single send)
 	if (NULL == statepp)
 	{
-		cgiResponseCommonMultiCleanup((void *)&statep);
+		cgiResponseCommonMultiCleanup(statep);
 		return HTTPD_CGI_DONE;
 	}
 	// else if finished sending

--- a/util/cgi_common.c
+++ b/util/cgi_common.c
@@ -236,12 +236,19 @@ CgiStatus cgiResponseCommonMulti(HttpdConnData *connData, void **statepp, char *
 		}
 	}
 
-	if (statep->len_to_send <= 0 || // finished sending
-		(statepp == NULL))			// or called without state pointer (single send)
+	// if called without state pointer (single send)
+	if (NULL == statepp)
 	{
 		cgiResponseCommonMultiCleanup((void *)&statep);
 		return HTTPD_CGI_DONE;
 	}
+	// else if finished sending
+	if (statep->len_to_send <= 0)
+	{
+		cgiResponseCommonMultiCleanup(statepp);
+		return HTTPD_CGI_DONE;
+	}
+	// else still sending
 	return HTTPD_CGI_MORE;
 }
 

--- a/util/cgi_common.c
+++ b/util/cgi_common.c
@@ -158,6 +158,7 @@ CgiStatus cgiResponseCommonMultiCleanup(void **statepp)
 		{
 			if (statep->toFree)
 			{
+				ESP_LOGD(__func__, "freeing");
 				free(statep->toFree);
 			}
 			free(statep); // clear state
@@ -238,8 +239,7 @@ CgiStatus cgiResponseCommonMulti(HttpdConnData *connData, void **statepp, char *
 	if (statep->len_to_send <= 0 || // finished sending
 		(statepp == NULL))			// or called without state pointer (single send)
 	{
-		ESP_LOGD(__func__, "freeing");
-		cgiResponseCommonMultiCleanup(statepp);
+		cgiResponseCommonMultiCleanup((void *)&statep);
 		return HTTPD_CGI_DONE;
 	}
 	return HTTPD_CGI_MORE;


### PR DESCRIPTION
We are having a memory leak.
Every time we GET a certain API, it uses an extra ~330 bytes. The memory leak is growing slowly but will take a very long time to exhaust the entire 2 or 4MB of RAM that we have.

It is looking like the memory leak is in the esphttpd task. (I used https://github.com/espressif/esp-idf/blob/release/v4.4/examples/system/heap_task_tracking/README.md )
The leak is further narrowed down to cgi that uses this helper function: `cgiJsonResponseCommonSingle()`

In this function it called `cgiJsonResponseCommonMulti()` with NULL as arg for a state pointer-pointer. I.e. 
`cgiJsonResponseCommonMulti(connData, NULL, jsroot);`

The actual bug is at the end of  `cgiJsonResponseCommonMulti()` where it should free memory: 
```c
	if (statep->len_to_send <= 0 || // finished sending
		(statepp == NULL))			// or called without state pointer (single send)
	{
		cgiResponseCommonMultiCleanup(statepp);
		return HTTPD_CGI_DONE;
	}
```
Notice that if `statepp` was passed in NULL, then it incorrectly passes a null pointer to `cgiResponseCommonMultiCleanup()`.

The corrected code passes in a pointer to the local pointer: 
```c
	if (statep->len_to_send <= 0 || // finished sending
		(statepp == NULL))			// or called without state pointer (single send)
	{
		cgiResponseCommonMultiCleanup((void *)&statep);
		return HTTPD_CGI_DONE;
	}
```